### PR TITLE
[MINOR] Adding process type to SDK initializer; Adding message to init-sdk response

### DIFF
--- a/Sources/minds-sdk-mobile-ios/core/networking/Services/BiometricService.swift
+++ b/Sources/minds-sdk-mobile-ios/core/networking/Services/BiometricService.swift
@@ -21,7 +21,8 @@ class BiometricServices: BiometricProtocol {
         self.env = env
     }
     
-    func sendAudio(token: String, request: AudioRequest, completion: @escaping (Result<BiometricResponse, NetworkError>) -> Void) {
+    func sendAudio(token: String, request: AudioRequest,
+                   completion: @escaping (Result<BiometricResponse, NetworkError>) -> Void) {
         let endpoint = BiometricsEndpoints.biometrics(requestBody: request)
         let request = endpoint.createRequest(token: token, environment: env)
         self.networkRequest.request(request) { result in
@@ -29,7 +30,8 @@ class BiometricServices: BiometricProtocol {
         }
     }
 
-    func validateInput(token: String, request: ValidateInputRequest, completion: @escaping (Result<ValidateInputResponse, NetworkError>) -> Void) {
+    func validateInput(token: String, request: ValidateInputRequest,
+                       completion: @escaping (Result<ValidateInputResponse, NetworkError>) -> Void) {
         let endpoint = BiometricsEndpoints.validateDataInput(requestBody: request)
         let request = endpoint.createRequest(token: token, environment: env)
         self.networkRequest.request(request) { result in
@@ -97,12 +99,14 @@ struct ValidateInputRequest: Codable {
     let checkForVerification: Bool
     let phoneNumber: String
     let rate: Int
+    let action: String
 
     enum CodingKeys: String, CodingKey {
         case cpf
         case fileExtension = "extension"
         case checkForVerification = "check_for_verification"
         case phoneNumber = "phone_number"
+        case action
         case rate
     }
 }
@@ -110,5 +114,6 @@ struct ValidateInputRequest: Codable {
 struct ValidateInputResponse: Codable {
     let success: Bool
     let message: String?
+    let result: Bool?
     let status: String
 }

--- a/Sources/minds-sdk-mobile-ios/core/sdk/MindsSDK.swift
+++ b/Sources/minds-sdk-mobile-ios/core/sdk/MindsSDK.swift
@@ -14,10 +14,10 @@ public class MindsSDK: ObservableObject {
     
     public init() { }
 
-    public enum ProcessType {
+    public enum ProcessType: String {
         case enrollment, verification
     }
-    
+
     @Published public var token: String = ""
     @Published public var cpf: String = ""
     @Published public var externalId: String = ""
@@ -32,7 +32,9 @@ public class MindsSDK: ObservableObject {
         self.processType = processType
     }
 
-    public func initializeSDK(completion: @escaping (Result<Void, Error>) -> Void) {
+    public func initializeSDK(for processType: ProcessType,
+                              completion: @escaping (Result<Void, Error>) -> Void) {
+        setProcessType(processType: processType)
         self.validateDataInput { dataInputResult in
             switch dataInputResult {
             case .success:
@@ -49,7 +51,8 @@ public class MindsSDK: ObservableObject {
             fileExtension: "wav",
             checkForVerification: processType == .verification,
             phoneNumber: phoneNumber,
-            rate: sampleRate
+            rate: sampleRate,
+            action: processType.rawValue
         )
 
         BiometricServices.init(networkRequest: NetworkManager())


### PR DESCRIPTION
This PR adds:
- `process type` to SDK initialization
- `result` flag to validate-sdk-init service response
- `action` parameter to validate-sdk-init service request body