### PR TITLE
[PATCH] Adding custom errors

### DIFF
--- a/Sources/minds-sdk-mobile-ios/core/errors/MindsSDKErrors.swift
+++ b/Sources/minds-sdk-mobile-ios/core/errors/MindsSDKErrors.swift
@@ -1,0 +1,52 @@
+//
+//  File.swift
+//  
+//
+//  Created by Guilherme Domingues on 20/07/22.
+//
+
+import Foundation
+
+public enum MindsSDKError: Error, Equatable {
+    case invalidCPF(String?)
+    case invalidPhoneNumber(String?)
+    case invalidAudioFormat(String?)
+    case customerNotFoundToPerformVerification(String?)
+    case customerNotEnrolled(String?)
+    case customerNotCertified(String?)
+    case internalServerException
+
+    public init(_ serverResponse: String, message: String?) {
+        switch serverResponse {
+        case "invalid_cpf":
+            self = MindsSDKError.invalidCPF(message)
+        case "invalid_phone_number":
+            self = MindsSDKError.invalidPhoneNumber(message)
+        case "invalid_sample_rate":
+            self = MindsSDKError.invalidAudioFormat(message)
+        case "customer_not_found_to_perform_verification":
+            self = MindsSDKError.customerNotFoundToPerformVerification(message)
+        case "customer_not_enrolled":
+            self = MindsSDKError.customerNotEnrolled(message)
+        case "customer_not_certified":
+            self = MindsSDKError.invalidAudioFormat(message)
+        default:
+            self = MindsSDKError.internalServerException
+        }
+    }
+
+    public static func ==(lhs: MindsSDKError, rhs: MindsSDKError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidCPF, .invalidCPF),
+                (.invalidPhoneNumber, .invalidPhoneNumber),
+            (.invalidAudioFormat, .invalidAudioFormat),
+            (.customerNotFoundToPerformVerification, .customerNotFoundToPerformVerification),
+            (.customerNotEnrolled, .customerNotEnrolled),
+            (.customerNotCertified, .customerNotCertified),
+            (.internalServerException, .internalServerException):
+            return true
+        default: return false
+        }
+    }
+
+}

--- a/Sources/minds-sdk-mobile-ios/core/sdk/MindsSDK.swift
+++ b/Sources/minds-sdk-mobile-ios/core/sdk/MindsSDK.swift
@@ -91,7 +91,7 @@ public class MindsSDK: ObservableObject {
             }
     }
 
-    private func validateDataInput(completion: @escaping (Result<Void, NetworkError>) -> Void) {
+    private func validateDataInput(completion: @escaping (Result<Void, Error>) -> Void) {
         let request = ValidateInputRequest(
             cpf: cpf,
             fileExtension: "ogg",
@@ -104,8 +104,9 @@ public class MindsSDK: ObservableObject {
             .validateInput(token: token, request: request) { result in
                 switch result {
                 case .success(let response):
-                    if !response.success  {
-                        completion(.failure(.serverError))
+                    if !response.success {
+                        let error = MindsSDKError(response.status, message: response.message)
+                        completion(.failure(error))
                         assertionFailure("\(response.status) - \(response.message ?? "")")
                     } else {
                         completion(.success(()))


### PR DESCRIPTION
## Examples

▿ MindsSDKError
  ▿ invalidPhoneNumber : Optional<String>
    - some : "Telefone inválido. (parâmetro `phone_number`)."

▿ MindsSDKError
  ▿ invalidCPF : Optional<String>
    - some : "CPF inválido. (parâmetro `cpf`)."

▿ MindsSDKError
  ▿ invalidAudioFormat : Optional<String>
    - some : "Não é possível utilizar o modelo necessário com a taxa de amostragem (sample_rate) do áudio enviado."

  ▿ customerNotFoundToPerformVerification : Optional<String>
    - some : "Não foi possível realizar uma ação `verification`, pois não há dados de cadastro desse cliente."

